### PR TITLE
Allele specific copy number information is returned via the mutations…

### DIFF
--- a/model/src/main/java/org/cbioportal/model/AlleleSpecificCopyNumber.java
+++ b/model/src/main/java/org/cbioportal/model/AlleleSpecificCopyNumber.java
@@ -1,0 +1,79 @@
+package org.cbioportal.model;
+
+import java.io.Serializable;
+
+public class AlleleSpecificCopyNumber implements Serializable {
+
+    private Integer ascnIntegerCopyNumber;
+    private String ascnMethod;
+    private Float ccfMCopiesUpper;
+    private Float ccfMCopies;
+    private Boolean clonal;
+    private Integer minorCopyNumber;
+    private Integer mutantCopies;
+    private Integer totalCopyNumber;
+
+    public Integer getAscnIntegerCopyNumber() {
+        return ascnIntegerCopyNumber;
+    }
+
+    public void setAscnIntegerCopyNumber(Integer ascnIntegerCopyNumber) {
+        this.ascnIntegerCopyNumber = ascnIntegerCopyNumber;
+    }
+
+    public String getAscnMethod() {
+        return ascnMethod;
+    }
+
+    public void setAscnMethod(String ascnMethod) {
+        this.ascnMethod = ascnMethod;
+    }
+
+    public Float getCcfMCopiesUpper() {
+        return ccfMCopiesUpper;
+    }
+
+    public void setCcfMCopiesUpper(Float ccfMCopiesUpper) {
+        this.ccfMCopiesUpper = ccfMCopiesUpper;
+    }
+
+    public Float getCcfMCopies() {
+        return ccfMCopies;
+    }
+
+    public void setCcfMCopies(Float ccfMCopies) {
+        this.ccfMCopies = ccfMCopies;
+    }
+
+    public Boolean getClonal() {
+        return clonal;
+    }
+
+    public void setClonal(Boolean clonal) {
+        this.clonal = clonal;
+    }
+
+    public Integer getMinorCopyNumber() {
+        return minorCopyNumber;
+    }
+
+    public void setMinorCopyNumber(Integer minorCopyNumber) {
+        this.minorCopyNumber = minorCopyNumber;
+    }
+
+    public Integer getMutantCopies() {
+        return mutantCopies;
+    }
+
+    public void setMutantCopies(Integer mutantCopies) {
+        this.mutantCopies = mutantCopies;
+    }
+
+    public Integer getTotalCopyNumber() {
+        return totalCopyNumber;
+    }
+
+    public void setTotalCopyNumber(Integer totalCopyNumber) {
+        this.totalCopyNumber = totalCopyNumber;
+    }
+} 

--- a/model/src/main/java/org/cbioportal/model/Mutation.java
+++ b/model/src/main/java/org/cbioportal/model/Mutation.java
@@ -2,7 +2,6 @@ package org.cbioportal.model;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
-import javax.validation.constraints.NotNull;
 
 public class Mutation extends Alteration implements Serializable {
     
@@ -36,6 +35,7 @@ public class Mutation extends Alteration implements Serializable {
     private String driverFilterAnnotation;
     private String driverTiersFilter;
     private String driverTiersFilterAnnotation;
+    private AlleleSpecificCopyNumber alleleSpecificCopyNumber;
     
     public String getCenter() {
         return center;
@@ -271,5 +271,13 @@ public class Mutation extends Alteration implements Serializable {
     
     public void setDriverTiersFilterAnnotation(String driverTiersFilterAnnotation) {
         this.driverTiersFilterAnnotation = driverTiersFilterAnnotation;
+    }
+
+    public AlleleSpecificCopyNumber getAlleleSpecificCopyNumber() {
+        return alleleSpecificCopyNumber;
+    }
+
+    public void setAlleleSpecificCopyNumber(AlleleSpecificCopyNumber alleleSpecificCopyNumber) {
+        this.alleleSpecificCopyNumber = alleleSpecificCopyNumber;
     }
 }

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -48,6 +48,10 @@
             <include refid="org.cbioportal.persistence.mybatis.GeneMapper.select">
                 <property name="prefix" value="gene."/>
             </include>
+            ,
+            <include refid="getAlleleSpecificCopyNumber">
+                <property name="prefix" value="alleleSpecificCopyNumber."/>
+            </include>
         </if>
     </sql>
 
@@ -151,6 +155,17 @@
         </where>
     </sql>
 
+    <sql id="getAlleleSpecificCopyNumber">
+        allele_specific_copy_number.ASCN_INTEGER_COPY_NUMBER AS "${prefix}ascnIntegerCopyNumber",
+        allele_specific_copy_number.ASCN_METHOD AS "${prefix}ascnMethod",
+        allele_specific_copy_number.CCF_M_COPIES_UPPER AS "${prefix}ccfMCopiesUpper",
+        allele_specific_copy_number.CCF_M_COPIES AS "${prefix}ccfMCopies",
+        allele_specific_copy_number.CLONAL AS "${prefix}clonal",
+        allele_specific_copy_number.MINOR_COPY_NUMBER AS "${prefix}minorCopyNumber",
+        allele_specific_copy_number.MUTANT_COPIES AS "${prefix}mutantCopies",
+        allele_specific_copy_number.TOTAL_COPY_NUMBER AS "${prefix}totalCopyNumber"
+    </sql>
+
     <select id="getMutationsBySampleListId" resultType="org.cbioportal.model.Mutation">
         SELECT
         <include refid="select"/>
@@ -160,6 +175,9 @@
         </if>
         <if test="projection == 'DETAILED'">
             INNER JOIN gene ON mutation.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
+            LEFT JOIN allele_specific_copy_number ON mutation.MUTATION_EVENT_ID = allele_specific_copy_number.MUTATION_EVENT_ID
+            AND mutation.GENETIC_PROFILE_ID = allele_specific_copy_number.GENETIC_PROFILE_ID
+            AND mutation.SAMPLE_ID = allele_specific_copy_number.SAMPLE_ID
         </if>
         <include refid="whereBySampleListId"/>
         <if test="sortBy != null and projection != 'ID'">


### PR DESCRIPTION
...API endpoint.

We don't really need the `${prefix}` in `MutationMapper.xml` `getAlleleSpecificCopyNumber` because we know for the `Mutation` class the `AlleleSpecificCopyNumber` property is called `alleleSpecificCopyNumber`, but I have left it anyway.  

Co-authored-by: Avery Wang <18199796+averyniceday@users.noreply.github.com>